### PR TITLE
Imports

### DIFF
--- a/py4hw/__init__.py
+++ b/py4hw/__init__.py
@@ -1,12 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from .base import Logic
-from .base import HWSystem 
-from .base import Wire
-from .logic import Add
-from .logic import And 
-from .logic import Scope 
-from .simulation import Simulator 
+from .base import *
+from .logic import *
+from .simulation import *
 
 import py4hw.gui
 import py4hw.debug


### PR DESCRIPTION
D'aquesta forma no s'ha d'afegir a l'init cada mòdul que es crea, però es continua tenint selectivitat (ex. from py4hw import Add).
També permet no haver-se de complicar amb els imports (més de cara als alumnes, es pot resoldre tot amb un from py4hw import * i no s'han de preocupar per pràcticament res més)