### PR TITLE
Scope and Waveform Reworked + Simulator Singleton issue

### DIFF
--- a/py4hw/logic.py
+++ b/py4hw/logic.py
@@ -66,9 +66,6 @@ class Or(Logic):
                 aux = parent.wire('{}{}'.format(name, idx), w)
                 idx = idx + 1
 
-
-
-
 class And(Logic):
     """
     Binary And
@@ -561,30 +558,43 @@ class Comparator(Logic):
 
 class Scope(Logic):
 
-    def __init__(self, parent, name: str, x: Wire):
+    def __init__(self, parent: Logic, name: str, wires):
         """
-
-
         Parameters
         ----------
-        parent : TYPE
-            Parent cell.
+        parent : Logic
+            Parent circuit.
         name : str
             Name of the instance.
-        x : Wire
-            Wire to monitor.
+        x
+            Wire or list of wire to monitor.
 
         Returns
         -------
         None.
-
         """
-        super().__init__(parent, name)
-        self.name = name
-        self.x = self.addIn("x", x)
 
-    def propagate(self):
-        print("{}={}".format(self.name, self.x.get()))
+        super().__init__(parent, name)
+        self.wires = wires if isinstance(wires, list) else [wires]
+        for x in self.wires:
+            self.addIn(x.name, x)
+
+        # Get simulator
+        sim = parent
+        while sim.parent != None:
+            sim = sim.parent
+
+        sim.getSimulator().addListener(self)
+
+    def simulatorUpdated(self):
+        head = f"Scope [{self.name}]:"
+        print(head)
+
+        for x in self.wires:
+            print(f"{x.name}={x.get()}")
+
+        print("-"*len(head))
+        
 
 
 class Waveform(Logic):

--- a/py4hw/schematic.py
+++ b/py4hw/schematic.py
@@ -150,6 +150,8 @@ class Schematic:
         self.mapping[Buf] = BufSymbol
         self.mapping[Bit] = BitSymbol
         self.mapping[Mux2] = Mux2Symbol
+
+        self.mapping[Waveform] = ScopeSymbol # Temp solution
         
         
         self.placeInputPorts()

--- a/py4hw/simulation.py
+++ b/py4hw/simulation.py
@@ -19,6 +19,9 @@ class Simulator:
         None.
 
         """
+        if sys.simulator != None:
+            return
+
         self.sys = sys;
         
         self.topologicalSort()
@@ -26,7 +29,12 @@ class Simulator:
         
         for obj in self.propagatables:
             obj.propagate();
-        
+    
+    def __new__(cls, sys:HWSystem):
+        if sys.simulator != None:
+            return sys.simulator
+        else:
+            return super().__new__(cls)
 
         
     def topologicalSort(self):
@@ -47,7 +55,6 @@ class Simulator:
         
         self.clockables = []
         self.propagatables = []
-        self.wave_scopes = []
        
         leaves = self.sys.allLeaves()
         
@@ -56,8 +63,6 @@ class Simulator:
                 self.clockables.append(leaf)
             if (leaf.isPropagatable()):
                 self.propagatables.append(leaf)
-            if (isinstance(leaf, Waveform)):
-                self.wave_scopes.append(leaf)
                 
         # Now sort the propagatables list
         anyChange = True 
@@ -157,19 +162,3 @@ class Simulator:
     def _notifyListeners(self):
         for listener in self.listeners:
             listener.simulatorUpdated()
-    
-    def get_waveform(self, name:str = "", with_ck = True):
-      signals = [wf.get_wave_raw() for wf in self.wave_scopes]
-      if (with_ck):
-          cklen = len(signals[0]["wave"])-1
-          signals.insert(0, {"name": "CK", "wave": "P" + "."*cklen})
-
-      waveform = {
-        "signal": signals,
-        "head":{
-          "text": name,
-          "tock": 0,
-        }
-      }
-      
-      return waveform


### PR DESCRIPTION
Now both Scope and Waveform blocks can handle many wires, and rely on simulation events rather than on clocking (which means WF and Simulator are not tightly coupled anymore).

Furthermore, while working on that, I found myself having some trouble with the Simulator class. At the moment, you have to (seemingly equal) ways of obtaining a simulator: via sys.getSimulator() or via Simulator(). However, while getSimulator() guarantees there's only one Simulator in a HWSys, Simulator() always creates a new Simulator. Since Scopes and Waveforms are attached to the hierarchy, and rely on being notified from that hierarchy's Simulator, this difference causes trouble.

So, I modified Simulator class so, if a given HWSys already has a Simulator, you get that one instead of a new one.