### PR TITLE
Minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+.gitignore
 .vscode
+.ipynb_checkpoints
 py4hw/__pycache__
+idees.txt

--- a/py4hw/__init__.py
+++ b/py4hw/__init__.py
@@ -8,3 +8,5 @@ from .schematic import *
 
 import py4hw.gui
 import py4hw.debug
+
+from nbwavedrom import draw as draw_waveform

--- a/py4hw/base.py
+++ b/py4hw/base.py
@@ -401,6 +401,8 @@ class HWSystem(Logic):
 
         if (self.simulator == None):
             self.simulator = Simulator(self)
+        else: 
+            self.simulator.topologicalSort() # Updates existing simulator
             
         return self.simulator
         

--- a/py4hw/base.py
+++ b/py4hw/base.py
@@ -203,7 +203,7 @@ class Wire:
     # this is the list of prepared wires, 
     prepared = []
     
-    def __init__(self, parent, name : str, width: int ):
+    def __init__(self, parent, name : str, width: int = 1 ):
         self.parent = parent
         self.name = name
         self.width = width

--- a/py4hw/logic.py
+++ b/py4hw/logic.py
@@ -290,7 +290,7 @@ class Constant(Logic):
     A constant value
     """
 
-    def __init__(self, parent: Logic, name: str, value, r: Wire):
+    def __init__(self, parent: Logic, name: str, value: int, r: Wire):
         super().__init__(parent, name)
         self.value = value
         self.r = self.addOut("r", r)
@@ -304,7 +304,7 @@ class Sequence(Logic):
     A sequence of value
     """
 
-    def __init__(self, parent: Logic, name: str, values, r: Wire):
+    def __init__(self, parent: Logic, name: str, values: list(int), r: Wire):
         super().__init__(parent, name)
         self.r = self.addOut("r", r)
 

--- a/py4hw/logic.py
+++ b/py4hw/logic.py
@@ -304,7 +304,7 @@ class Sequence(Logic):
     A sequence of value
     """
 
-    def __init__(self, parent: Logic, name: str, values: list[int], r: Wire):
+    def __init__(self, parent: Logic, name: str, values: list(), r: Wire):
         super().__init__(parent, name)
         self.r = self.addOut("r", r)
 

--- a/py4hw/logic.py
+++ b/py4hw/logic.py
@@ -619,7 +619,7 @@ class Waveform(Logic):
         self.wires = wires if isinstance(wires, list) else [wires]
         for x in self.wires:
             self.addIn(x.name, x)
-            self.waves[x] = {"name": name, "wave": "x", "data": []}
+            self.waves[x] = {"name": x.name, "wave": "x", "data": []}
             self.prevs[x] = None
 
         # Get simulator

--- a/py4hw/logic.py
+++ b/py4hw/logic.py
@@ -299,6 +299,22 @@ class Constant(Logic):
         self.r.put(self.value)
         #print(self.name, '=', self.value)
 
+class Sequence(Logic):
+    """
+    A sequence of value
+    """
+
+    def __init__(self, parent: Logic, name: str, values, r: Wire):
+        super().__init__(parent, name)
+        self.r = self.addOut("r", r)
+
+        self.values = values
+        self.n = len(values)
+        self.i = 0
+        
+    def clock(self):
+        self.r.prepare(self.values[self.i])
+        self.i = ( self.i +1 ) % self.n
 
 class SignExtend(Logic):
     def __init__(self, parent: Logic, name: str, a: Wire, r: Wire):

--- a/py4hw/logic.py
+++ b/py4hw/logic.py
@@ -304,7 +304,7 @@ class Sequence(Logic):
     A sequence of value
     """
 
-    def __init__(self, parent: Logic, name: str, values: list(int), r: Wire):
+    def __init__(self, parent: Logic, name: str, values: list[int], r: Wire):
         super().__init__(parent, name)
         self.r = self.addOut("r", r)
 

--- a/py4hw/simulation.py
+++ b/py4hw/simulation.py
@@ -32,6 +32,7 @@ class Simulator:
     
     def __new__(cls, sys:HWSystem):
         if sys.simulator != None:
+            sys.simulator.topologicalSort() # Updates existing simulator
             return sys.simulator
         else:
             return super().__new__(cls)


### PR DESCRIPTION
- Bugfix with simulation/scope/waveform
- Default wire width to match _Logic.wire()_ behaviour
- Added _Gitignore_
- Added _nbwavedrom_ import, so you don't have to import it separately